### PR TITLE
Adjust copy on hero page, add quack sound to mobile nav

### DIFF
--- a/src/components/mobile-nav/mobile-nav.component.tsx
+++ b/src/components/mobile-nav/mobile-nav.component.tsx
@@ -2,7 +2,12 @@ import { MobileNavContainer, MobileNavMenuItem } from "./mobile-nav.styled";
 import { Link } from "react-scroll";
 import { useEffect } from "react";
 
+import useSound from "use-sound";
+import quack from "../../assets/sounds/quackTrimmed.mp3";
+
 const MobileNav = ({ setIsMobileNavOpen, isMobileNavOpen }: any) => {
+  const [playQuack] = useSound(quack);
+
   useEffect(() => {
     const handleBodyOverflow = () => {
       if (isMobileNavOpen) {
@@ -20,6 +25,7 @@ const MobileNav = ({ setIsMobileNavOpen, isMobileNavOpen }: any) => {
   }, [isMobileNavOpen]);
 
   function closeMobileNav() {
+    playQuack();
     setIsMobileNavOpen(false);
   }
 

--- a/src/containers/hero/hero.component.tsx
+++ b/src/containers/hero/hero.component.tsx
@@ -8,8 +8,8 @@ import {
 
 const HeroPageText = {
   heading: "Lurry-lore",
-  subheading: "All about Lurry's not-so-dramatic past",
-  paragraph: `On the planet of Lurdonia, a group of scientists engineered an army of mutated rubber ducks, they primed for Galactic conquest.  
+  subheading: "All about Lurry's dramatic hero-origin arc",
+  paragraph: `On the planet of Lurdonia, a group of scientists engineered an army of mutated rubber ducks, primed for Galactic conquest.  
 
     Yet, the Lurry's wanted no part in global conquest, and were desperate to escape. 
     


### PR DESCRIPTION
- adjust copy on hero page -> subheading + body text
- add "quack" sound to mobile nav menu item presses